### PR TITLE
Fix browser DoH compatibility

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,27 +3,38 @@ name: docker
 on:
   push:
     branches:
-      - 'master'
+      - "master"
+  pull_request:
+    branches: ["master"]
 
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Login to Docker Hub
+
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
+
+      - name: Define Docker tag
+        id: vars
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "tag=pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: tiennt/doh-server:latest
+          tags: tiennt/doh-server:${{ steps.vars.outputs.tag }}
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +161,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-throttle"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
  "axum-core",
  "bytes",
@@ -318,6 +349,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-test"
+version = "18.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680e88effaafbb28675074f29cda0e984c984bed5eb513085c17caf7de564225"
+dependencies = [
+ "anyhow",
+ "axum",
+ "bytes",
+ "bytesize",
+ "cookie",
+ "expect-json",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "mime",
+ "pretty_assertions",
+ "reserve-port",
+ "rust-multipart-rfc7578_2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "tokio",
+ "tower",
+ "url",
+]
+
+[[package]]
 name = "backoff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,10 +466,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "bytesize"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5c434ae3cf0089ca203e9019ebe529c47ff45cefe8af7c85ecb734ef541822f"
 
 [[package]]
 name = "cc"
@@ -436,6 +508,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clang-sys"
@@ -581,6 +666,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,6 +764,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,6 +807,7 @@ dependencies = [
  "axum",
  "axum-extra",
  "axum-server",
+ "axum-test",
  "base64 0.22.1",
  "clap 4.5.35",
  "config",
@@ -712,6 +820,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-test",
  "tokio-utils",
  "tower",
  "tower-http",
@@ -740,6 +849,15 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -780,6 +898,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "259d404d09818dec19332e31d94558aeb442fea04c817006456c24b5460bbd4b"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +916,34 @@ checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "expect-json"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7519e78573c950576b89eb4f4fe82aedf3a80639245afa07e3ee3d199dcdb29e"
+dependencies = [
+ "chrono",
+ "email_address",
+ "expect-json-macros",
+ "num",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.16",
+ "typetag",
+ "uuid",
+]
+
+[[package]]
+name = "expect-json-macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bf7f5979e98460a0eb412665514594f68f366a32b85fa8d7ffb65bb1edee6a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -848,6 +1005,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,8 +1029,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1033,13 +1198,14 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -1047,8 +1213,10 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -1058,13 +1226,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
 dependencies = [
  "bytes",
+ "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "libc",
  "pin-project-lite",
+ "socket2 0.5.9",
  "tokio",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1226,6 +1422,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,6 +1497,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "json5"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,9 +1531,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
@@ -1427,12 +1653,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -1448,6 +1697,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1552,7 +1823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
 dependencies = [
  "memchr",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "ucd-trie",
 ]
 
@@ -1633,6 +1904,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,9 +1925,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -1756,7 +2037,7 @@ dependencies = [
  "pin-project-lite",
  "ryu",
  "sha1_smol",
- "socket2",
+ "socket2 0.5.9",
  "tokio",
  "tokio-util",
  "url",
@@ -1816,6 +2097,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "reserve-port"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21918d6644020c6f6ef1993242989bf6d4952d2e025617744f184c02df51c356"
+dependencies = [
+ "thiserror 2.0.16",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1850,6 +2140,21 @@ dependencies = [
  "cfg-if",
  "ordered-multimap",
  "trim-in-place",
+]
+
+[[package]]
+name = "rust-multipart-rfc7578_2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c839d037155ebc06a571e305af66ff9fd9063a6e662447051737e1ac75beea41"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "mime",
+ "rand 0.9.0",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -1960,18 +2265,28 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1980,14 +2295,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2097,6 +2413,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2122,9 +2448,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2181,11 +2507,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -2201,9 +2527,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2272,20 +2598,22 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2307,6 +2635,30 @@ checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -2484,6 +2836,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "tub"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2494,10 +2852,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "typetag"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f22b40dd7bfe8c14230cf9702081366421890435b2d625fa92b4acc4c3de6f"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f5380909ffc31b4de4f4bdf96b877175a016aa2ca98cee39fcfd8c4d53d952"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "ucd-trie"
@@ -2560,12 +2948,14 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "getrandom 0.3.2",
+ "js-sys",
  "rand 0.9.0",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2587,6 +2977,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2599,6 +2998,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2634,6 +3092,65 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2775,6 +3292,12 @@ dependencies = [
  "encoding_rs",
  "hashlink",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yasna"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,13 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.117"
 tempfile = "3.10.1"
 tokio = { version = "1.37.0", features = ["full"] }
-tower = { version = "0.5.2", features = [
-    "util",
-    "timeout",
+tower = { version = "0.5.2", features = ["util", "timeout"] }
+tower-http = { version = "0.6.2", features = [
+  "timeout",
+  "trace",
+  "sensitive-headers",
+  "catch-panic",
 ] }
-tower-http = { version = "0.6.2", features = ["timeout", "trace", "sensitive-headers", "catch-panic"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 config = "0.15.11"
@@ -36,4 +38,3 @@ env_logger = "0.11.8"
 axum-test = "18.1.0"
 base64 = "0.22.1"
 tokio-test = "0.4.3"
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,8 @@ redis = { version = "0.29.2", features = ["tokio-comp"] }
 dotenv = { version = "0.15.0", features = ["clap"] }
 env_logger = "0.11.8"
 
+[dev-dependencies]
+axum-test = "18.1.0"
+base64 = "0.22.1"
+tokio-test = "0.4.3"
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.79 as build
+FROM rust:1.89 as build
 WORKDIR /doh-server
 
 COPY Cargo.toml Cargo.lock ./

--- a/src/dns/buffer.rs
+++ b/src/dns/buffer.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use redis::{ErrorKind, FromRedisValue, RedisError, RedisResult, RedisWrite, ToRedisArgs, Value};
 
-pub const MAX_SIZE: usize = 1024;
+pub const MAX_SIZE: usize = 4096;
 pub struct BytePacketBuffer {
     pub buf: [u8; MAX_SIZE], // need to optimize this
     pub pos: usize,

--- a/src/dns/header.rs
+++ b/src/dns/header.rs
@@ -24,6 +24,12 @@ pub struct DnsHeader {
     pub resource_entries: u16,
 }
 
+impl Default for DnsHeader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DnsHeader {
     pub fn new() -> DnsHeader {
         DnsHeader {
@@ -53,7 +59,7 @@ impl DnsHeader {
         self.recursion_desired = (a & (1 << 0)) > 0;
         self.truncated_message = (a & (1 << 1)) > 0;
         self.authoritative_answer = (a & (1 << 2)) > 0;
-        self.opcode = (1 >> 3) & 0x0F;
+        self.opcode = (a >> 3) & 0x0F;
         self.response = (a & (1 << 7)) > 0;
 
         self.rescode = ResultCode::from_num(b & 0x0F);

--- a/src/dns/mod.rs
+++ b/src/dns/mod.rs
@@ -205,6 +205,10 @@ pub async fn recursive_lookup(
     }
 }
 
+pub fn preserve_response_id(response: &mut DnsPacket, request_id: u16) {
+    response.header.id = request_id;
+}
+
 pub fn postfixes(qname: &str) -> Vec<String> {
     let mut result = Vec::new();
     let split = qname.rsplit(".");
@@ -234,5 +238,15 @@ mod tests {
         let vec = postfixes("mail.google.com");
 
         assert_eq!(vec!("mail.google.com", "google.com", "com"), vec)
+    }
+
+    #[test]
+    fn test_preserve_response_id() {
+        let mut packet = DnsPacket::new();
+        packet.header.id = 6666;
+
+        preserve_response_id(&mut packet, 0);
+
+        assert_eq!(0, packet.header.id);
     }
 }

--- a/src/dns/record.rs
+++ b/src/dns/record.rs
@@ -107,7 +107,7 @@ impl DnsRecord {
                 let mut cname = String::new();
                 buffer.read_qname(&mut cname)?;
 
-                Ok(DnsRecord::NS {
+                Ok(DnsRecord::CNAME {
                     domain,
                     host: cname,
                     ttl,
@@ -415,7 +415,7 @@ impl DnsPacket {
                         _ => None,
                     })
             })
-            .map(|addr| *addr)
+            .copied()
             .next()
     }
 

--- a/src/http/dns.rs
+++ b/src/http/dns.rs
@@ -13,7 +13,7 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 
 use serde_derive::Deserialize;
 
-pub(crate) fn router() -> Router<ApiContext> {
+pub fn router() -> Router<ApiContext> {
     Router::new()
         .route("/dns-query", get(handle_get))
         .route("/dns-query", post(handle_post))
@@ -24,17 +24,28 @@ async fn handle_get(
     headers: HeaderMap,
     Query(params): Query<DnsQueryParams>,
 ) -> impl IntoResponse {
-    let question = params.to_dns_question().unwrap();
+    let question = match params.to_dns_question() {
+        Ok(q) => q,
+        Err(_) => return DnsResponse::BadRequest().into_response(),
+    };
+
     let socket = state.udp_socket_pool.acquire().await;
-    let mut result = recursive_lookup(
+    let mut result = match recursive_lookup(
         socket.as_ref(),
         state.redis_conn.clone(),
         &question.name,
         question.qtype,
     )
     .await
-    .unwrap();
-    DnsResponse::from_packet(headers, &mut result).unwrap()
+    {
+        Ok(r) => r,
+        Err(_) => return DnsResponse::BadRequest().into_response(),
+    };
+
+    match DnsResponse::from_packet(headers, &mut result) {
+        Ok(response) => response.into_response(),
+        Err(_) => DnsResponse::BadRequest().into_response(),
+    }
 }
 
 async fn handle_post(
@@ -42,29 +53,51 @@ async fn handle_post(
     headers: HeaderMap,
     body: Bytes,
 ) -> impl IntoResponse {
+    // Validate Content-Type for POST requests
+    if let Some(content_type) = headers.get(header::CONTENT_TYPE) {
+        if content_type != "application/dns-message" {
+            return DnsResponse::BadRequest().into_response();
+        }
+    }
+
+    // Validate body size
+    if body.len() > MAX_SIZE {
+        return DnsResponse::BadRequest().into_response();
+    }
+
     let mut buf: [u8; MAX_SIZE] = [0; MAX_SIZE];
     let bytes = body.as_ref();
     buf[..bytes.len()].copy_from_slice(bytes);
 
     let mut req_buffer: BytePacketBuffer = BytePacketBuffer { buf, pos: 0 };
-    let packet = DnsPacket::from_buffer(&mut req_buffer).unwrap();
-    // todo: handle multiple questions
+    let packet = match DnsPacket::from_buffer(&mut req_buffer) {
+        Ok(p) => p,
+        Err(_) => return DnsResponse::BadRequest().into_response(),
+    };
+
+    // Handle multiple questions (browsers typically send one)
     if let Some(q) = packet.questions.first() {
         let socket = state.udp_socket_pool.acquire().await;
-        let mut result = recursive_lookup(socket.as_ref(), state.redis_conn, &q.name, q.qtype)
-            .await
-            .unwrap();
-        DnsResponse::from_packet(headers, &mut result).unwrap()
+        let mut result =
+            match recursive_lookup(socket.as_ref(), state.redis_conn, &q.name, q.qtype).await {
+                Ok(r) => r,
+                Err(_) => return DnsResponse::BadRequest().into_response(),
+            };
+
+        match DnsResponse::from_packet(headers, &mut result) {
+            Ok(response) => response.into_response(),
+            Err(_) => DnsResponse::BadRequest().into_response(),
+        }
     } else {
-        DnsResponse::BadRequest()
+        DnsResponse::BadRequest().into_response()
     }
 }
 
 #[derive(Debug, Deserialize)]
 pub struct DnsQueryParams {
-    dns: Option<String>,
-    name: Option<String>,
-    r#type: Option<String>,
+    pub dns: Option<String>,
+    pub name: Option<String>,
+    pub r#type: Option<String>,
     // r#do: Option<String>,
     // cd: Option<String>,
 }
@@ -72,15 +105,27 @@ pub struct DnsQueryParams {
 impl DnsQueryParams {
     pub fn to_dns_question(self) -> anyhow::Result<DnsQuestion> {
         if let Some(dns) = self.dns {
+            // Handle base64url-encoded DNS message
             let decoded = URL_SAFE_NO_PAD.decode(dns)?;
-            let question = String::from_utf8(decoded).map(|qname| DnsQuestion {
-                name: qname,
-                qtype: QueryType::A,
-            })?;
-            return Ok(question);
+            if decoded.len() < 12 {
+                return Err(anyhow::anyhow!("DNS message too short"));
+            }
+
+            let mut buffer = BytePacketBuffer::from_bytes(&decoded);
+            let packet = DnsPacket::from_buffer(&mut buffer)?;
+
+            if let Some(question) = packet.questions.first() {
+                return Ok(question.clone());
+            } else {
+                return Err(anyhow::anyhow!("No questions in DNS message"));
+            }
         }
 
         if let Some(name) = self.name {
+            if name.is_empty() || name.len() > 253 {
+                return Err(anyhow::anyhow!("Invalid domain name"));
+            }
+
             return if let Some(qtype) = self.r#type {
                 Ok(DnsQuestion {
                     name,
@@ -94,7 +139,7 @@ impl DnsQueryParams {
             };
         }
 
-        Err(anyhow::anyhow!("Either dns or name is required!"))
+        Err(anyhow::anyhow!("Either dns or name parameter is required!"))
     }
 }
 
@@ -106,27 +151,37 @@ pub enum DnsResponse {
 
 impl DnsResponse {
     pub fn from_packet(headers: HeaderMap, result: &mut DnsPacket) -> anyhow::Result<DnsResponse> {
-        let accept_content_type: String = headers.get(header::ACCEPT).map_or(
-            "application/dns-message".to_string(),
-            |accept: &header::HeaderValue| accept.to_str().unwrap().to_lowercase(),
-        );
+        // Parse Accept header to determine preferred content type
+        let accept_header = headers
+            .get(header::ACCEPT)
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or("application/dns-message");
 
-        match accept_content_type.as_str() {
-            "application/dns-message" => {
-                let mut buffer: BytePacketBuffer = BytePacketBuffer::new();
-                result.write(&mut buffer).unwrap();
+        // Check if client accepts dns-message (preferred for browsers)
+        let accepts_dns_message =
+            accept_header.contains("application/dns-message") || accept_header.contains("*/*");
 
-                let len = buffer.pos();
-                let data = buffer.get_range(0, len)?;
-                Ok(DnsResponse::DnsMessage(data.to_vec()))
-            }
-            "application/dns-json" => {
-                let json_result = result.as_json();
-                Ok(DnsResponse::DnsJson(
-                    serde_json::to_vec(&json_result).unwrap(),
-                ))
-            }
-            _ => Ok(DnsResponse::BadRequest()),
+        // Check if client specifically requests dns-json
+        let accepts_dns_json = accept_header.contains("application/dns-json");
+
+        if accepts_dns_message {
+            let mut buffer: BytePacketBuffer = BytePacketBuffer::new();
+            result.write(&mut buffer)?;
+
+            let len = buffer.pos();
+            let data = buffer.get_range(0, len)?;
+            Ok(DnsResponse::DnsMessage(data.to_vec()))
+        } else if accepts_dns_json {
+            let json_result = result.as_json();
+            Ok(DnsResponse::DnsJson(serde_json::to_vec(&json_result)?))
+        } else {
+            // Default to dns-message for browsers
+            let mut buffer: BytePacketBuffer = BytePacketBuffer::new();
+            result.write(&mut buffer)?;
+
+            let len = buffer.pos();
+            let data = buffer.get_range(0, len)?;
+            Ok(DnsResponse::DnsMessage(data.to_vec()))
         }
     }
 }
@@ -136,17 +191,36 @@ impl IntoResponse for DnsResponse {
         match self {
             DnsResponse::DnsJson(body) => (
                 StatusCode::OK,
-                [(header::CONTENT_TYPE, "application/dns-json")],
+                [
+                    (header::CONTENT_TYPE, "application/dns-json"),
+                    (header::ACCESS_CONTROL_ALLOW_ORIGIN, "*"),
+                    (header::ACCESS_CONTROL_ALLOW_METHODS, "GET, POST"),
+                    (header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type"),
+                ],
                 body,
             )
                 .into_response(),
             DnsResponse::DnsMessage(body) => (
                 StatusCode::OK,
-                [(header::CONTENT_TYPE, "application/dns-message")],
+                [
+                    (header::CONTENT_TYPE, "application/dns-message"),
+                    (header::ACCESS_CONTROL_ALLOW_ORIGIN, "*"),
+                    (header::ACCESS_CONTROL_ALLOW_METHODS, "GET, POST"),
+                    (header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type"),
+                ],
                 body,
             )
                 .into_response(),
-            DnsResponse::BadRequest() => StatusCode::BAD_REQUEST.into_response(),
+            DnsResponse::BadRequest() => (
+                StatusCode::BAD_REQUEST,
+                [
+                    (header::ACCESS_CONTROL_ALLOW_ORIGIN, "*"),
+                    (header::ACCESS_CONTROL_ALLOW_METHODS, "GET, POST"),
+                    (header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type"),
+                ],
+                "Bad Request",
+            )
+                .into_response(),
         }
     }
 }

--- a/src/http/dns.rs
+++ b/src/http/dns.rs
@@ -1,13 +1,13 @@
 use crate::dns::buffer::{BytePacketBuffer, MAX_SIZE};
 use crate::dns::query::{DnsQuestion, QueryType};
 use crate::dns::record::DnsPacket;
-use crate::dns::recursive_lookup;
+use crate::dns::{preserve_response_id, recursive_lookup};
 use crate::http::ApiContext;
 use axum::body::Bytes;
 use axum::extract::{Query, State};
 use axum::http::{header, HeaderMap, StatusCode};
 use axum::response::IntoResponse;
-use axum::routing::{get, post};
+use axum::routing::{get, options, post};
 use axum::Router;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 
@@ -17,6 +17,7 @@ pub fn router() -> Router<ApiContext> {
     Router::new()
         .route("/dns-query", get(handle_get))
         .route("/dns-query", post(handle_post))
+        .route("/dns-query", options(handle_options))
 }
 
 async fn handle_get(
@@ -24,8 +25,8 @@ async fn handle_get(
     headers: HeaderMap,
     Query(params): Query<DnsQueryParams>,
 ) -> impl IntoResponse {
-    let question = match params.to_dns_question() {
-        Ok(q) => q,
+    let request = match params.to_dns_request() {
+        Ok(request) => request,
         Err(_) => return DnsResponse::BadRequest().into_response(),
     };
 
@@ -33,14 +34,18 @@ async fn handle_get(
     let mut result = match recursive_lookup(
         socket.as_ref(),
         state.redis_conn.clone(),
-        &question.name,
-        question.qtype,
+        &request.question.name,
+        request.question.qtype,
     )
     .await
     {
         Ok(r) => r,
         Err(_) => return DnsResponse::BadRequest().into_response(),
     };
+
+    if let Some(request_id) = request.id {
+        preserve_response_id(&mut result, request_id);
+    }
 
     match DnsResponse::from_packet(headers, &mut result) {
         Ok(response) => response.into_response(),
@@ -53,11 +58,8 @@ async fn handle_post(
     headers: HeaderMap,
     body: Bytes,
 ) -> impl IntoResponse {
-    // Validate Content-Type for POST requests
-    if let Some(content_type) = headers.get(header::CONTENT_TYPE) {
-        if content_type != "application/dns-message" {
-            return DnsResponse::BadRequest().into_response();
-        }
+    if !is_dns_message_content_type(&headers) {
+        return DnsResponse::UnsupportedMediaType().into_response();
     }
 
     // Validate body size
@@ -74,6 +76,7 @@ async fn handle_post(
         Ok(p) => p,
         Err(_) => return DnsResponse::BadRequest().into_response(),
     };
+    let request_id = packet.header.id;
 
     // Handle multiple questions (browsers typically send one)
     if let Some(q) = packet.questions.first() {
@@ -84,6 +87,8 @@ async fn handle_post(
                 Err(_) => return DnsResponse::BadRequest().into_response(),
             };
 
+        preserve_response_id(&mut result, request_id);
+
         match DnsResponse::from_packet(headers, &mut result) {
             Ok(response) => response.into_response(),
             Err(_) => DnsResponse::BadRequest().into_response(),
@@ -91,6 +96,31 @@ async fn handle_post(
     } else {
         DnsResponse::BadRequest().into_response()
     }
+}
+
+async fn handle_options() -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        [
+            (header::ACCESS_CONTROL_ALLOW_ORIGIN, "*"),
+            (header::ACCESS_CONTROL_ALLOW_METHODS, "GET, POST, OPTIONS"),
+            (header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type"),
+            (header::ACCESS_CONTROL_MAX_AGE, "86400"),
+        ],
+        "",
+    )
+}
+
+fn is_dns_message_content_type(headers: &HeaderMap) -> bool {
+    headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|content_type| content_type.to_str().ok())
+        .and_then(|content_type| content_type.split(';').next())
+        .is_some_and(|media_type| {
+            media_type
+                .trim()
+                .eq_ignore_ascii_case("application/dns-message")
+        })
 }
 
 #[derive(Debug, Deserialize)]
@@ -102,8 +132,13 @@ pub struct DnsQueryParams {
     // cd: Option<String>,
 }
 
+pub struct DnsRequest {
+    pub id: Option<u16>,
+    pub question: DnsQuestion,
+}
+
 impl DnsQueryParams {
-    pub fn to_dns_question(self) -> anyhow::Result<DnsQuestion> {
+    pub fn to_dns_request(self) -> anyhow::Result<DnsRequest> {
         if let Some(dns) = self.dns {
             // Handle base64url-encoded DNS message
             let decoded = URL_SAFE_NO_PAD.decode(dns)?;
@@ -115,7 +150,10 @@ impl DnsQueryParams {
             let packet = DnsPacket::from_buffer(&mut buffer)?;
 
             if let Some(question) = packet.questions.first() {
-                return Ok(question.clone());
+                return Ok(DnsRequest {
+                    id: Some(packet.header.id),
+                    question: question.clone(),
+                });
             } else {
                 return Err(anyhow::anyhow!("No questions in DNS message"));
             }
@@ -127,14 +165,20 @@ impl DnsQueryParams {
             }
 
             return if let Some(qtype) = self.r#type {
-                Ok(DnsQuestion {
-                    name,
-                    qtype: QueryType::from_str(qtype),
+                Ok(DnsRequest {
+                    id: None,
+                    question: DnsQuestion {
+                        name,
+                        qtype: QueryType::from_str(qtype),
+                    },
                 })
             } else {
-                Ok(DnsQuestion {
-                    name,
-                    qtype: QueryType::A,
+                Ok(DnsRequest {
+                    id: None,
+                    question: DnsQuestion {
+                        name,
+                        qtype: QueryType::A,
+                    },
                 })
             };
         }
@@ -147,6 +191,7 @@ pub enum DnsResponse {
     DnsJson(Vec<u8>),
     DnsMessage(Vec<u8>),
     BadRequest(),
+    UnsupportedMediaType(),
 }
 
 impl DnsResponse {
@@ -194,7 +239,7 @@ impl IntoResponse for DnsResponse {
                 [
                     (header::CONTENT_TYPE, "application/dns-json"),
                     (header::ACCESS_CONTROL_ALLOW_ORIGIN, "*"),
-                    (header::ACCESS_CONTROL_ALLOW_METHODS, "GET, POST"),
+                    (header::ACCESS_CONTROL_ALLOW_METHODS, "GET, POST, OPTIONS"),
                     (header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type"),
                 ],
                 body,
@@ -205,7 +250,7 @@ impl IntoResponse for DnsResponse {
                 [
                     (header::CONTENT_TYPE, "application/dns-message"),
                     (header::ACCESS_CONTROL_ALLOW_ORIGIN, "*"),
-                    (header::ACCESS_CONTROL_ALLOW_METHODS, "GET, POST"),
+                    (header::ACCESS_CONTROL_ALLOW_METHODS, "GET, POST, OPTIONS"),
                     (header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type"),
                 ],
                 body,
@@ -215,12 +260,75 @@ impl IntoResponse for DnsResponse {
                 StatusCode::BAD_REQUEST,
                 [
                     (header::ACCESS_CONTROL_ALLOW_ORIGIN, "*"),
-                    (header::ACCESS_CONTROL_ALLOW_METHODS, "GET, POST"),
+                    (header::ACCESS_CONTROL_ALLOW_METHODS, "GET, POST, OPTIONS"),
                     (header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type"),
                 ],
                 "Bad Request",
             )
                 .into_response(),
+            DnsResponse::UnsupportedMediaType() => (
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                [
+                    (header::ACCESS_CONTROL_ALLOW_ORIGIN, "*"),
+                    (header::ACCESS_CONTROL_ALLOW_METHODS, "GET, POST, OPTIONS"),
+                    (header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type"),
+                ],
+                "Unsupported Media Type",
+            )
+                .into_response(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    #[test]
+    fn accepts_dns_message_content_type_with_parameters() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/dns-message; charset=utf-8"),
+        );
+
+        assert!(is_dns_message_content_type(&headers));
+    }
+
+    #[test]
+    fn rejects_missing_or_wrong_content_type() {
+        assert!(!is_dns_message_content_type(&HeaderMap::new()));
+
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+        assert!(!is_dns_message_content_type(&headers));
+    }
+
+    #[test]
+    fn parses_dns_query_id_from_get_wire_message() {
+        let mut packet = DnsPacket::new();
+        packet.header.id = 42;
+        packet
+            .questions
+            .push(DnsQuestion::new("example.com".to_string(), QueryType::A));
+
+        let mut buffer = BytePacketBuffer::new();
+        packet.write(&mut buffer).unwrap();
+        let len = buffer.pos();
+        let dns = URL_SAFE_NO_PAD.encode(buffer.get_range(0, len).unwrap());
+
+        let request = DnsQueryParams {
+            dns: Some(dns),
+            name: None,
+            r#type: None,
+        }
+        .to_dns_request()
+        .unwrap();
+
+        assert_eq!(request.id, Some(42));
+        assert_eq!(request.question.name, "example.com");
+        assert_eq!(request.question.qtype, QueryType::A);
     }
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,4 +1,4 @@
-mod dns;
+pub mod dns;
 
 use crate::settings::{Server, Tls};
 use axum::body::Body;
@@ -26,9 +26,9 @@ use tracing_subscriber::util::SubscriberInitExt;
 use uuid::Uuid;
 
 #[derive(Clone)]
-pub(crate) struct ApiContext {
-    udp_socket_pool: Pool<Arc<UdpSocket>>,
-    redis_conn: Arc<Mutex<MultiplexedConnection>>,
+pub struct ApiContext {
+    pub udp_socket_pool: Pool<Arc<UdpSocket>>,
+    pub redis_conn: Arc<Mutex<MultiplexedConnection>>,
 }
 
 pub async fn serve(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod cache;
+pub mod dns;
+pub mod http;
+pub mod settings;
+pub mod tls;

--- a/tests/doh_simple_tests.rs
+++ b/tests/doh_simple_tests.rs
@@ -1,0 +1,58 @@
+use anyhow::Result;
+use axum::http::{header, StatusCode};
+use axum_test::TestServer;
+use doh_server::http::dns;
+use redis::Client;
+use std::sync::Arc;
+use tokio::net::UdpSocket;
+use tokio::sync::Mutex;
+use tokio_utils::Pool;
+
+#[tokio::test]
+async fn test_doh_server_basic() -> Result<()> {
+    // Create UDP socket pool
+    let mut sockets = Vec::new();
+    for _ in 0..2 {
+        let socket = UdpSocket::bind("0.0.0.0:0").await?;
+        sockets.push(Arc::new(socket));
+    }
+    let socket_pool: Pool<Arc<UdpSocket>> = Pool::from_vec(sockets);
+
+    // Try to create Redis connection, but handle failure gracefully
+    let redis_conn = match Client::open("redis://127.0.0.1/") {
+        Ok(client) => {
+            match client.get_multiplexed_async_connection().await {
+                Ok(conn) => Arc::new(Mutex::new(conn)),
+                Err(_) => {
+                    // Skip Redis-dependent tests if Redis is not available
+                    println!("Redis not available, skipping test");
+                    return Ok(());
+                }
+            }
+        }
+        Err(_) => {
+            println!("Redis not available, skipping test");
+            return Ok(());
+        }
+    };
+
+    let api_context = doh_server::http::ApiContext {
+        udp_socket_pool: socket_pool,
+        redis_conn,
+    };
+
+    let app = dns::router().with_state(api_context);
+    let server = TestServer::new(app)?;
+
+    // Test basic GET endpoint
+    let response = server
+        .get("/dns-query?name=google.com&type=A")
+        .add_header(header::ACCEPT, "application/dns-message")
+        .await;
+
+    // The response might be OK or BAD_REQUEST depending on DNS resolution
+    // but the endpoint should be accessible
+    assert!(response.status_code() == StatusCode::OK || response.status_code() == StatusCode::BAD_REQUEST);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add OPTIONS /dns-query preflight response with browser CORS headers
- accept parameterized application/dns-message POST Content-Type values and return 415 for wrong/missing media types
- preserve the incoming DoH DNS transaction ID on wire-message responses for POST and GET dns= requests

## Testing
- Not run locally: cargo is not installed in this shell and Docker daemon is not running
- GitHub Actions started after push